### PR TITLE
Better monitor, exit command and discussed documentation fixes

### DIFF
--- a/include/kernel/monitor.h
+++ b/include/kernel/monitor.h
@@ -19,3 +19,4 @@ int mon_kerninfo(int argc, char **argv, struct int_frame *frame);
 int mon_backtrace(int argc, char **argv, struct int_frame *frame);
 int mon_buddyinfo(int argc, char **argv, struct int_frame *frame);
 int mon_pageinfo(int argc, char **argv, struct int_frame *frame);
+int mon_exit(int argc, char **argv, struct int_frame *frame);

--- a/kernel/mem/buddy.c
+++ b/kernel/mem/buddy.c
@@ -99,8 +99,7 @@ size_t count_total_free_pages(void)
  * no free buddy is found.
  *
  * The algorithm to merge pages is as follows:
- *  - Given the page of order k, locate the page with the lowest address
- *    and its buddy of order k.
+ *  - Given the page of order k locate its buddy of order k.
  *  - Check if both the page and the buddy are free and whether the order
  *    matches.
  *  - Remove the page and its buddy from the free list.

--- a/kernel/mem/init.c
+++ b/kernel/mem/init.c
@@ -92,7 +92,7 @@ void page_init(struct boot_info *boot_info)
 	/* Go through the array of struct page_info structs and:
 	 *  1) call list_init() to initialize the linked list node.
 	 *  2) set the reference count pp_ref to zero.
-	 *  3) mark the page as in use by setting pp_free to zero.
+	 *  3) mark the page as in use by setting pp_free to false.
 	 *  4) set the order pp_order to zero.
 	 */
 	for (i = 0; i < npages; ++i) {
@@ -104,8 +104,8 @@ void page_init(struct boot_info *boot_info)
 
 	/* Go through the entries in the memory map:
 	 *  1) Ignore the entry if the region is not free memory.
-	 *  2) Iterate through the pages in the region.
-	 *  3) If the physical address is above BOOT_MAP_LIM, ignore.
+	 *  2) Iterate through the region and separate it into pages.
+	 *  3) If the physical address is above or equal to BOOT_MAP_LIM, ignore.
 	 *  4) Hand the page to the buddy allocator by calling page_free() if
 	 *     the page is not reserved.
 	 *

--- a/kernel/monitor.c
+++ b/kernel/monitor.c
@@ -28,6 +28,7 @@ static struct command commands[] = {
 	{ "backtrace", "Display stack backtrace", mon_backtrace },
 	{ "buddyinfo", "Display debugging information for the buddy allocator", mon_buddyinfo },
 	{ "pageinfo", "Display page information for a given page index", mon_pageinfo },
+	{ "exit", "Exit the operating system", mon_exit}
 };
 
 #define NCOMMANDS (sizeof(commands)/sizeof(commands[0]))
@@ -136,6 +137,13 @@ int mon_pageinfo(int argc, char **argv, struct int_frame *frame)
 	return 0;
 }
 
+int mon_exit(int argc, char **argv, struct int_frame *frame) {
+  // This is a cheaty QEMU exit and not a proper shutdown. This could
+  // be a fun bonus assignment to set that up.
+  // Taken from: https://wiki.osdev.org/Shutdown
+  outw(0x604, 0x2000);
+  return 0;
+}
 /***** Kernel monitor command interpreter *****/
 
 #define WHITESPACE "\t\r\n "

--- a/lib/readline.c
+++ b/lib/readline.c
@@ -6,30 +6,132 @@ static char buf[BUFLEN];
 
 char *readline(const char *prompt)
 {
-	int i, c, echoing;
-
+    int i, c, echoing, buf_size;
+	int command_mode = 0;
+	
 	if (prompt != NULL)
 		cprintf("%s", prompt);
-
-	i = 0;
+	
+	i = 0, buf_size = 0;
+	
 	echoing = iscons(0);
 	while (1) {
 		c = getchar();
+
+		// Arrow keys
+		if (c == '[') { 
+		  command_mode = 1;
+		  continue;
+		}
+
+		if (command_mode) {
+		  command_mode = 0;
+		  if (c == 'D') {
+			  if (i <= 0) continue;
+			  
+			  // Cursor go left
+			  cprintf("\033[1D");
+			  i--;
+			continue;
+		  } else if (c == 'C') {
+			  if (i == buf_size) continue;
+			
+			  // Cursor go right 
+			  cprintf("\033[1C");
+			  i++;
+			continue;
+		  } else {
+			  cputchar('[');
+		  }
+		  
+		}
+		// Implement C-a for going to the start of the line
+		if (c == 0x1) {
+		  cprintf("\033[%dD", i);
+		  buf[i] = '\0';
+		  i = 0;
+		}
+
+		// Implement C-e for going to end of the line 
+		if (c == 0x5 && buf_size != i) {
+		  cprintf("\033[%dC", buf_size-i);
+		  i = buf_size;
+		}
 		if (c < 0) {
 			cprintf("read error: %e\n", c);
 			return NULL;
-		} else if ((c == '\b' || c == '\x7f') && i > 0) {
-			if (echoing)
+		} else if ((c == '\b' || c == '\x7f') && i > 0 && buf_size > 0) {
+			// If we are the end of the buffer we can just delete the
+			// last character and be done with it. 
+			if (i == buf_size) {
 				cputchar('\b');
-			i--;
-		} else if (c >= ' ' && i < BUFLEN-1) {
+				cputchar(' ');
+				cputchar('\b');
+				buf_size--;
+				i--;
+				continue;
+			}
+
+			// Go backwards by one
+			cputchar('\b');
+			
+			// Override the character with the rest of the buffer
+			int tmp = i;
+			while (i != buf_size) {
+				buf[i-1] = buf[i];
+				cputchar(buf[i]);
+				i++;
+			}
+
+			// Blank out the last character
+			cputchar(' ');
+			cputchar('\b');
+
+			// Move the cursor back to our old position and shrink the
+			// buffer
+			cprintf("\033[%dD", i - tmp);
+			i = tmp-1;
+
+			buf_size--;
+		// We ignore the 0x7f deletion character here since it is not
+		// a printable character and messes with backspace
+		} else if (c >= ' ' && i < BUFLEN-1 && c != 0x7f) {
 			if (echoing)
 				cputchar(c);
-			buf[i++] = c;
+			// In our easy path we can just add the element and move on
+			if (i == buf_size) {
+				buf[i++] = c;
+				buf_size++;
+				continue;
+			}
+
+			// Add our new character to the buffer and shift everything
+			// to the right.
+			int cursor = i;
+			char old = buf[i];
+			buf[i] = c;
+			while (i != buf_size) {
+				char tmp = buf[i+1];
+				buf[i+1] = old;
+				old = tmp;
+				i++;
+			}
+
+			// Increase our buffer and print it so we override the
+			// current output
+			buf_size++;
+			i = cursor+1;			
+			while (i != buf_size) {
+				cputchar(buf[i++]);
+			}
+
+			// Move the cursor backwards and set the right index
+			cprintf("\033[%dD", i - cursor-1);
+			i = cursor+1;
 		} else if (c == '\n' || c == '\r') {
 			if (echoing)
 				cputchar('\n');
-			buf[i] = 0;
+			buf[buf_size] = 0;
 			return buf;
 		}
 	}


### PR DESCRIPTION
Hi course staff,

During the debugging session with the TAs we discussed some changes to the lab that we agreed would be nice. Specifically adding the exit command from my implementation and changing some of the wording in the documentation. The documentation changes has been mostly discussed, besides step 2 of `page_init` which I changed to specify that you are iterating over _regions_ which includes _pages_ rather than iterating over _pages_ directly. 

In addition I have improved the readline function by adding support for:
- Start of line (C-a)
- End of line (C-e)
- Character deletion/prevent ghost characters
- Left and right arrow 
- Character insertion at arbitrator locations
- Character deletion at arbitrary locations

It does have mildly awkward insertion of `[` since that character is overloaded as also being the start of special characters like arrow or the home row